### PR TITLE
Add initial product categorization based on names

### DIFF
--- a/product_categories.txt
+++ b/product_categories.txt
@@ -1,0 +1,205 @@
+Bilstein B6 1977 Chevrolet Corvette Base Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1975-1991 Ford E-350 Econoline Rear Monotube Strut Assembly	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 46mm Monotube Shock Absorber Rear 71-03 Dodge Van	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 1975 Ford LTD Country Squire Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 1996 Ford Bronco XLT Sport Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 92-06 Ford E-150 Econoline Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 1984 Toyota Pickup Base RWD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1994 Dodge Ram 1500 Base RWD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1994 Dodge Ram 1500 Base RWD Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2003 Nissan Frontier Base Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 1993 Toyota T100 Base 4WD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2000 Nissan Xterra SE Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1994 Dodge Ram 1500 Base 4WD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1997 Dodge Ram 1500 Laramie 4WD Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 1995 Toyota Tacoma SR5 Rear Left 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 1995 Toyota Tacoma SR5 Rear Right 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2004 Toyota Tacoma Base RWD Front 36mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2003 Nissan Frontier Base Front 36mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2004 Nissan Frontier XE RWD Crew Cab Pickup Rear 36mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2005 Toyota Tacoma Base RWD Front Left 36mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2005 Toyota Tacoma Base RWD Front Right 36mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2005 Toyota Tacoma Base RWD Rear 36mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 97-04 Ford F-150/F-250 Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1997 Ford F-150 Base 4WD Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1977 Dodge D200 Base Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1977 Dodge D200 Base Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1994 Dodge Ram 2500 Base Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 1998 Ford Expedition Eddie Bauer 4WD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1997 Dodge Dakota Base 4WD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 1997 Dodge Dakota Base 4WD Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1998 Jeep Wrangler SE Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1998 Jeep Wrangler SE Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 1999 Ford F-250 Super Duty Lariat RWD Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 99-04 Ford Mustang SVT Cobra IRS Rear 46mm Heavy Duty Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 00-06 Toyota Tundra/01-07 Sequoia Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2000 Toyota Tundra Base Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 2003 Ford F-150 XLT RWD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2002 Ford Excursion Eddie Bauer RWD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2002 Ford Excursion Eddie Bauer RWD Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein B6 2002 Ford Excursion Eddie Bauer 4WD Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 4600 Series 00-05 Ford Excursion Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1984 Ford Bronco II Base Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1984 Ford Bronco II Base Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1980 Ford Bronco Custom Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1980 Ford Bronco Custom Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1995 Chevrolet Tahoe Base 4WD Sport Utility Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1984 Jeep Cherokee Base Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1984 Jeep Cherokee Base Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1987 Jeep Wrangler Base Front 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Bilstein 5100 Series 1987 Jeep Wrangler Base Rear 46mm Monotube Shock Absorber	Automotive > Performance Parts > Shocks, Struts & Suspension
+Power Stop 15-19 Ford Mustang Front Z26 Street Warrior Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 94-01 Acura Integra Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 14-15 Lexus IS250 Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 14-19 Infiniti Q50 Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 15-19 Subaru WRX Rear Z26 Street Warrior Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 90-00 Honda Civic Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 15-17 Chevrolet SS Rear Z26 Street Warrior Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 16-18 Cadillac CT6 Front Z26 Street Warrior Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 97-01 Acura Integra Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 16-18 Cadillac ATS Rear Z26 Street Warrior Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 15-18 Volkswagen Golf Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 15-18 Ford Focus Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 90-93 Mazda Miata Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 15-21 Volkswagen GTI Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 16-18 Cadillac CT6 Rear Z26 Street Warrior Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 17-20 Honda Civic Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 17-18 GMC Acadia Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 18-19 Buick Enclave Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 97-03 Ford Escort Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 16-19 Honda Civic Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 17-19 Honda Civic Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 18-19 Subaru Crosstrek Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 2019 Toyota Avalon Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 18-19 Toyota Camry Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 94-97 Mazda Miata Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 17-19 Honda Civic Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 18-19 Jeep Wrangler Front Z36 Truck & Tow Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 18-19 Jeep Wrangler Rear Z36 Truck & Tow Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 2018 Mercedes-Benz C43 AMG Front Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 2018 Mercedes-Benz C43 AMG Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 18-19 Infiniti Q50 Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Power Stop 2018 Ford Expedition Rear Z23 Evolution Sport Brake Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+H&R 19mm Tapered M 12 x 1.5 Lug Nut	Automotive > Tires & Wheels > Wheel Accessories > Lug Nuts
+ICON 91-97 Toyota Land Cruiser 80 Series 3in Stage 1 Suspension System	Automotive > Performance Parts > Suspension Systems
+K&N 06-09 Chevy Corvette Z06 V8-7.0L Aircharger Performance Intake	Automotive > Performance Parts > Intake Systems
+Mahle MS Piston Set 2016 Ford 5.0L 314ci 3.7in Bore 3.65in Stroke 5.933in Rod .866 Pin 7.3cc 12.3 CR	Automotive > Replacement Parts > Engine Parts > Pistons & Rings
+Mahle OE Cummins B 5.9L L6 .020 w/ PC Eng Set Piston Set (Set of 6)	Automotive > Replacement Parts > Engine Parts > Pistons & Rings
+Project Kics 12X1.50 Gunmetal Leggdura Racing Lug Nuts (Laser Logo) - 20 PCS	Automotive > Tires & Wheels > Wheel Accessories > Lug Nuts
+Rockford Fosgate 1998-2013 Harley Davidson Road Glide Stage 2 Audio Kit	Electronics > Car & Vehicle Electronics > Car Audio > Audio Systems
+Rugged Ridge Roll Bar Cover Black Polyester 07-18 Jeep Wrangler JK	Automotive > Interior Accessories > Roll Bar Accessories
+Skyjacker 2.5&quot;SR 73-87 GM 1/2 W/RR SP	Automotive > Performance Parts > Shocks, Struts & Suspension
+Skyjacker 2.5&quot;SYS 73-87 1/2T SUB 52&quot;	Automotive > Performance Parts > Suspension Systems
+SpeedStrap SpeedStrap Small Tool Bag	Tools & Home Improvement > Tool Organization > Tool Bags
+Access LOMAX Tri-Fold Cover Black Urethane Finish 02-19 Dodge Ram - 5ft 7in Bed (w/o RamBox)	Automotive > Exterior Accessories > Truck Bed Accessories > Tonneau Covers
+AVS 97-01 Toyota Camry Carflector Low Profile Hood Shield - Smoke	Automotive > Exterior Accessories > Body > Hood Deflectors & Shields
+AVS 23-24 Honda Accord Aeroskin Low Profile Acrylic Hood Shield - Smoke	Automotive > Exterior Accessories > Body > Hood Deflectors & Shields
+AVS 23-24 Ford Escape Aeroskin Low Profile Hood Shield - Smoke	Automotive > Exterior Accessories > Body > Hood Deflectors & Shields
+Cometic Honda F20/22C1 S2000 88mm .040 inch MLS 2.0L Head Gasket	Automotive > Replacement Parts > Gaskets & Seals > Head Gaskets
+Cometic Corvette C7 Gen 5 SBC 6.2L LT1 .021in MLS Exhaust Gasket (1.920in)	Automotive > Replacement Parts > Gaskets & Seals > Exhaust Gaskets
+Cometic Chevy Small Block 4.165 inch Bore .051 inch MLS Head Gasket (w/All Steam Holes)	Automotive > Replacement Parts > Gaskets & Seals > Head Gaskets
+Cometic 1992+ Dodge 8.0L Viper .012in Fiber Intake Manifold Gasket	Automotive > Replacement Parts > Gaskets & Seals > Intake Manifold Gaskets
+Corsa 2021-2024 Ford F-150 Regular Cab/6.5in Bed 5.0L V8 Xtreme Cat-Back Single Side Exit-Polished	Automotive > Performance Parts > Exhaust Systems > Cat-Back Exhausts
+Corsa 2021-2024 Ford F-150 Regular Cab/6.5in Bed 5.0L V8 Xtreme Cat-Back Dual Rear Exit-Black PVD	Automotive > Performance Parts > Exhaust Systems > Cat-Back Exhausts
+DEI Heat Screen GOLD 36in x 40in - Non-Adhesive	Automotive > Interior Accessories > Heat & Sound Deadening
+DEI 18-23 Jeep Wrangler JL 4-Door Boom Mat Headliner - 9 Piece - Black	Automotive > Interior Accessories > Heat & Sound Deadening
+EBC 2017+ Audi Q7 BSD Front Rotors	Automotive > Replacement Parts > Brakes > Brake Rotors
+EBC 2019+ Chevrolet Silverado 1500 (2WD) Yellowstuff Rear Brake Pads	Automotive > Replacement Parts > Brakes > Brake Pads
+EBC 96-98 BMW Z3 1.9L Bluestuff Rear Brake Pads	Automotive > Replacement Parts > Brakes > Brake Pads
+EBC S4 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S5 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S5 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S9 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S9 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+Eibach 14-21 Ram 2500 Diesel 4WD Pro-Truck Rear Springs	Automotive > Performance Parts > Shocks, Struts & Suspension
+Energy Suspension Ford Trans Mount 2.312 CTR - Red	Automotive > Replacement Parts > Mounts > Transmission Mounts
+Ford Racing 15-24 Ford Mustang GT / 15-20 Ford Mustang GT350 Front Adjustable Strut Mounts	Automotive > Replacement Parts > Mounts > Strut Mounts
+Gaerne SG12 Boot Black Size - 14	Apparel > Motorcycle & Powersports Gear > Footwear > Boots
+Gaerne SG12 Boot Black Size - 8	Apparel > Motorcycle & Powersports Gear > Footwear > Boots
+Gaerne SG12 Boot White Size - 13	Apparel > Motorcycle & Powersports Gear > Footwear > Boots
+Gaerne SG12 Boot Black/Fluorescent Yellow Size - 10.5	Apparel > Motorcycle & Powersports Gear > Footwear > Boots
+Gaerne SG12 Boot Black/Fluorescent Yellow Size - 12	Apparel > Motorcycle & Powersports Gear > Footwear > Boots
+Gaerne SG 12 Boot Enduro Black Size - 7	Apparel > Motorcycle & Powersports Gear > Footwear > Boots
+ICON Recon Pro 17x8.5 6x5.5 0mm Offset 4.75in BS 106.1mm Bore Charcoal Wheel	Automotive > Tires & Wheels > Wheels
+Injen 19-22 Ram 2500/3500 I6-6.7L Diesel Evolution Intake - Dry Filter	Automotive > Performance Parts > Intake Systems
+King Nissan VR38DETT pMaxKote Performance Con Rod Bearing Set - Size +0.25mm	Automotive > Replacement Parts > Engine Parts > Bearings
+KW Coilover Kit V3 BMW 3series E90/E92 2WDSedan + Coupe	Automotive > Performance Parts > Shocks, Struts & Suspension
+LIQUI MOLY 5L Special Tec V Motor Oil SAE 0W20	Automotive > Oils & Fluids > Motor Oil
+Mahle OE Cms 102mm/4.017 Bore ISB OE 3970192 Bare 05-08 17.1:1 CR Vin C Piston Set (Set of 6)	Automotive > Replacement Parts > Engine Parts > Pistons & Rings
+Mahle OE Dodge Eagle HEMI 5.7L 0.50MM 2009-12 Dodge Charger Challenger Durango Piston Set (Set of 8)	Automotive > Replacement Parts > Engine Parts > Pistons & Rings
+Brembo 13-15 Land Rover LR2 Premium NAO Ceramic OE Equivalent Pad - Rear	Automotive > Replacement Parts > Brakes > Brake Pads
+Brembo 18-20 Jaguar E-Pace Premium Low-Met OE Equivalent Pad - Rear	Automotive > Replacement Parts > Brakes > Brake Pads
+Brembo 90-07 Honda Accord/03-14 Civic/97-00 CR-V/13-14 Fit Rear Drum Brake Shoe	Automotive > Replacement Parts > Brakes > Brake Shoes
+Burly Brand Touring Sport Fairing Standard	Motorcycle & Powersports > Accessories > Body Parts > Fairings
+Burly Brand Springer Fork Lowering Kit	Motorcycle & Powersports > Parts > Suspension > Lowering Kits
+Burly Brand Narrow Ape 16in - Chrome	Motorcycle & Powersports > Accessories > Handlebars & Controls
+Burly Brand Control Kit ABS 14in - Back	Motorcycle & Powersports > Accessories > Handlebars & Controls
+Bushwacker 20-21 GMC Sierra 2500/2500HD/3500HD (Excl. Dually) Pocket Style 4pc Flares - Blk	Automotive > Exterior Accessories > Body > Fender Flares
+Bushwacker 99-06 Chevy Silverado 1500 Fleetside Rail Caps 96.0in Bed Does Not Fit Flareside - Black	Automotive > Exterior Accessories > Truck Bed Accessories > Bed Rail Caps
+Bushwacker 02-08 Dodge Ram 1500 Fleetside Extend-A-Fender Style Flares 2pc - Black	Automotive > Exterior Accessories > Body > Fender Flares
+Carrillo BMW S58B30 5.945in Carrillo Rod w/ 3/8 CARR-PS Bolt 0.0065in-0.0075in	Automotive > Replacement Parts > Engine Parts > Rods
+Chemical Guys New Car Smell Air Freshener & Odor Eliminator - 4oz	Automotive > Interior Accessories > Air Fresheners
+Clevite Continental Y69 91 112 Series 4 Cyl Con Rod Bearing Set	Automotive > Replacement Parts > Engine Parts > Bearings
+Clutch Masters 17-18 Honda Civic Type-R 2.0L FX400 6-Puck Ceramic Sprung Disc Clutch Kit	Automotive > Replacement Parts > Transmission & Drivetrain > Clutches & Parts
+Clutch Masters Universal Replacement Steel Flywheel Insert	Automotive > Replacement Parts > Transmission & Drivetrain > Flywheels
+Cometic 15-18 Ford Mustang 2.3L / 16-18 Ford Focus 2.3L / 13-15 Lincoln MKZ 2.0L Valve Cover Set	Automotive > Replacement Parts > Gaskets & Seals > Valve Cover Gaskets
+Cometic Scion 2AZFE 2.4L 01-UP Exhaust .030 inch MLS Head Gasket 1.890 inch Round Port	Automotive > Replacement Parts > Gaskets & Seals > Head Gaskets
+Cometic Street Pro 2007 Subaru STi EJ257 DOHC 101mm Bore Complete Gasket Kit *OEM # 10105AB080*	Automotive > Replacement Parts > Gaskets & Seals > Gasket Kits
+COMP Cams Camshaft Da6 260S	Automotive > Replacement Parts > Engine Parts > Camshafts
+CRG 15-17 Yamaha R3 RC2 Brake Lever - Standard Red	Motorcycle & Powersports > Parts > Brakes > Brake Levers
+CRG 99-20 Yamaha R6/ R1S RC2 Clutch Lever -Short Red	Motorcycle & Powersports > Parts > Brakes > Clutch Levers
+CRG 05-06 Kawasaki ZX6R/ RR/ 04-20 Suzuki GSXR600-1000R/ 06-17 Triumph Brake Lever -Std Red	Motorcycle & Powersports > Parts > Brakes > Brake Levers
+CRG 15-16 Yamaha YZF-R1 RC2 Brake Lever - Short Red	Motorcycle & Powersports > Parts > Brakes > Brake Levers
+CSF 03-07 Mitsubishi Lancer 2.0L OEM Plastic Radiator	Automotive > Replacement Parts > Cooling & Heating > Radiators
+Cusco LSD Type-RS 1.5-Way (1&1.5 Way) Rear 15-24 Subaru WRX / 18-23 Crosstrek 6MT Only	Automotive > Performance Parts > Drivetrain > Differentials
+Cylinder Works 99-23 Yamaha YZ 250 250cc Standard Bore Cylinder Kit	Motorcycle & Powersports > Parts > Engine > Cylinders & Kits
+DBA 13-14 Ford Mustang GT500 w/ Brembo Front Drilled/Slotted 5000 Series 2 Piece Rotor w/ Black Hat	Automotive > Replacement Parts > Brakes > Brake Rotors
+DeatschWerks 92-08 Volvo L5 Turbo White Block 650cc Injectors - Set of 5	Automotive > Replacement Parts > Fuel System > Fuel Injectors
+Deezee 99-07 Chevrolet Silverado Tailgate Assist Shock	Automotive > Exterior Accessories > Truck Bed Accessories > Tailgate Assists
+Deezee 04-14 Ford F150 Tailgate Assist Shock	Automotive > Exterior Accessories > Truck Bed Accessories > Tailgate Assists
+Deezee 97-16 Ford F-Series Tailgate Assist Shock	Automotive > Exterior Accessories > Truck Bed Accessories > Tailgate Assists
+Deezee 15-23 Ford F150 Tailgate Assist Shock	Automotive > Exterior Accessories > Truck Bed Accessories > Tailgate Assists
+Deezee 2022-23 Ford Maverick Tailgate Assist Shock	Automotive > Exterior Accessories > Truck Bed Accessories > Tailgate Assists
+Deezee 02-09 Dodge Ram Tailgate Assist Shock	Automotive > Exterior Accessories > Truck Bed Accessories > Tailgate Assists
+Deezee Universal Tool Box - Specialty Narrow Black BT FULLSIZE	Automotive > Tools & Equipment > Tool Storage > Tool Boxes
+Deezee Universal Tool Box - Specialty Utility Chest Plastic 37In	Automotive > Tools & Equipment > Tool Storage > Tool Boxes
+Deezee 02-09 Dodge Ram Heavyweight Bed Mat - Custom Fit 6 1/2Ft Bed	Automotive > Exterior Accessories > Truck Bed Accessories > Bed Liners & Mats
+Deezee 15-23 Ford F150 Heavyweight Bed Mat - Custom Fit 5 1/2Ft Bed (X Pattern)	Automotive > Exterior Accessories > Truck Bed Accessories > Bed Liners & Mats
+Deezee 15-23 Ford F150 Heavyweight Bed Mat - Custom Fit 6 1/2Ft Bed (X Pattern)	Automotive > Exterior Accessories > Truck Bed Accessories > Bed Liners & Mats
+Deezee 19-23 Chevrolet Silverado Heavyweight Bed Mat - Custom Fit 5 1/2Ft Bed (X Pattern)	Automotive > Exterior Accessories > Truck Bed Accessories > Bed Liners & Mats
+Deezee Universal Tool Box - Red Crossover - Single Lid BT Alum Full Size	Automotive > Tools & Equipment > Tool Storage > Tool Boxes
+Deezee Universal Tool Box - Red Crossover - Single Lid Black BT Full Size	Automotive > Tools & Equipment > Tool Storage > Tool Boxes
+Deezee Universal Tool Box - Red Crossover - Double Black BT Full Size	Automotive > Tools & Equipment > Tool Storage > Tool Boxes
+Deezee Universal Tool Box - Red Chest Black BT 56In	Automotive > Tools & Equipment > Tool Storage > Tool Boxes
+Diode Dynamics 11-24 Dodge RAM 1500/2500/3500 High Beam SL2 LED Headlight Bulbs (Pair)	Automotive > Lights & Lighting Accessories > Light Bulbs > LED Bulbs
+DragonFire Racing Harness Pass Through Bezel	Automotive > Interior Accessories > Seat & Seat Cover Accessories
+DV8 Offroad 22-23 Toyota Tundra Center Console Molle Panels/Device Mount	Automotive > Interior Accessories > Consoles & Organizers
+Dynojet 23-24 Yamaha YZ450F Power Commander 6	Motorcycle & Powersports > Parts > Electronics > Fuel Management Systems
+Dynojet 23-24 Can-Am Outlander HD5/HD7 Power Commander 6	Motorcycle & Powersports > Parts > Electronics > Fuel Management Systems
+Dynojet 23-24 Kove 800X Power Commander 6	Motorcycle & Powersports > Parts > Electronics > Fuel Management Systems
+Dynojet 18-23 Can-Am Outlander Power Vision 3	Motorcycle & Powersports > Parts > Electronics > Fuel Management Systems
+EBC 93-98 Nissan Skyline (R33) 2.5 GTS Greenstuff Front Brake Pads	Automotive > Replacement Parts > Brakes > Brake Pads
+EBC 79-88 Porsche 924 2.0 Turbo Yellowstuff Rear Brake Pads	Automotive > Replacement Parts > Brakes > Brake Pads
+EBC 03-12 Mazda RX8 1.3 Rotary (Standard Suspension) Bluestuff Rear Brake Pads	Automotive > Replacement Parts > Brakes > Brake Pads
+EBC 18-23 Subaru Impreza 1.6L Bluestuff Front Brake Pads	Automotive > Replacement Parts > Brakes > Brake Pads
+EBC 05+ Toyota Tacoma 2WD 2.7 GD Sport Front Rotors	Automotive > Replacement Parts > Brakes > Brake Rotors
+EBC 06-12 Lexus ES350 3.5 GD Sport Rear Rotors	Automotive > Replacement Parts > Brakes > Brake Rotors
+EBC S10 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S10 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S11 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S11 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S11 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S12 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S12 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S12 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S13 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S13 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S15 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S1 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S20 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S3 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S4 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S4 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S5 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S6 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits
+EBC S9 Brake Pad and Rotor Kit	Automotive > Replacement Parts > Brakes > Brake Kits


### PR DESCRIPTION
This commit introduces a new file, product_categories.txt, which contains product names from categories1.txt mapped to a 1-3 level category structure.

The categorization logic is based on keyword matching within the product names, referencing common automotive and powersports categories similar to those found on e-commerce sites like Walmart.

Categories are formatted as Level1 > Level2 > Level3.